### PR TITLE
Setup SQS -> SNS subscription

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -50,6 +50,13 @@ resources:
       Type: AWS::SQS::Queue
       Properties:
         QueueName: AddListenToPlaylistQueue
+    ListenAddedSNSSubscription:
+      Type: AWS::SNS::Subscription
+      Properties:
+        Protocol: sqs
+        Endpoint: arn:aws:sqs:us-east-1:550212734867:AddListenToPlaylistQueue
+        TopicArn: arn:aws:sns:us-east-1:550212734867:ListenAddedSNSTopic
+
 
 plugins:
   - serverless-python-requirements


### PR DESCRIPTION
Manually setup this permissions policy in the console
```json
{
  "Version": "2012-10-17",
  "Id": "arn:aws:sqs:us-east-1:550212734867:AddListenToPlaylistQueue/SQSDefaultPolicy",
  "Statement": [
    {
      "Sid": "Sid1545532627495",
      "Effect": "Allow",
      "Principal": "*",
      "Action": "SQS:SendMessage",
      "Resource": "arn:aws:sqs:us-east-1:550212734867:AddListenToPlaylistQueue",
      "Condition": {
        "ArnEquals": {
          "aws:SourceArn": "arn:aws:sns:us-east-1:550212734867:ListenAddedSNSTopic"
        }
      }
    }
  ]
}
```